### PR TITLE
Fix recipe identifiers

### DIFF
--- a/PS4RemotePlay/PS4RemotePlay.install.recipe
+++ b/PS4RemotePlay/PS4RemotePlay.install.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Installs the PS4 Remote Play application.</string>
     <key>Identifier</key>
-    <string>com.github.poundbangbash.eholtam-recipes.download.ps4remoteplay</string>
+    <string>com.github.poundbangbash.eholtam-recipes.install.ps4remoteplay</string>
     <key>Input</key>
     <dict>
     </dict>

--- a/PowerPanel/PowerPanel.install.recipe
+++ b/PowerPanel/PowerPanel.install.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Installs the CyberPower PowerPanel app.</string>
     <key>Identifier</key>
-    <string>com.github.poundbangbash.eholtam-recipes.download.powerpanel</string>
+    <string>com.github.poundbangbash.eholtam-recipes.install.powerpanel</string>
     <key>Input</key>
     <dict>
         <key>APPNAME</key>


### PR DESCRIPTION
These two identifiers should probably be "install" instead of "download."