### PR TITLE
Updated Photomechanic recipes to detect and download version 6.

### DIFF
--- a/PhotoMechanic/PhotoMechanic.download.recipe
+++ b/PhotoMechanic/PhotoMechanic.download.recipe
@@ -11,11 +11,11 @@
         <key>NAME</key>
         <string>PhotoMechanic</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.camerabits.com/cgi-bin/download_pm.cgi?plat=mac</string>
+        <string>https://www.camerabits.com/cgi-bin/download_pm.cgi?plat=mac&amp;version=PRO</string>
         <key>USER_AGENT</key>
         <string>Mozilla/9.0</string>
         <key>MAJOR_VERSION</key>
-        <string>5</string>
+        <string>6</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.5.1</string>

--- a/PhotoMechanic/PhotoMechanic.munki.recipe
+++ b/PhotoMechanic/PhotoMechanic.munki.recipe
@@ -13,7 +13,7 @@
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/camerabits</string>
         <key>MAJOR_VERSION</key>
-        <string>5</string>
+        <string>6</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>

--- a/PhotoMechanic/PhotoMechanic.pkg.recipe
+++ b/PhotoMechanic/PhotoMechanic.pkg.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>PhotoMechanic</string>
 		<key>MAJOR_VERSION</key>
-		<string>5</string>
+		<string>6</string>
 	</dict>
     <key>ParentRecipe</key>
     <string>com.github.poundbangbash.eholtam-recipes.download.photomechanic</string>


### PR DESCRIPTION
Updated to satisfy https://github.com/autopkg/eholtam-recipes/issues/12