### PR TITLE
Update SizeUp.download.recipe

### DIFF
--- a/SizeUp/SizeUp.download.recipe
+++ b/SizeUp/SizeUp.download.recipe
@@ -9,7 +9,7 @@
         <key>NAME</key>
         <string>SizeUp</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://www.irradiatedsoftware.com/download/SizeUp.zip</string>
+        <string>http://www.irradiatedsoftware.com/download/SizeUp.zip</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17</string>
     </dict>


### PR DESCRIPTION
Looks like one of the certificates has expired according to https://www.sslshopper/ssl-checker.html

And seems related to this whole fiasco: https://calnetweb.berkeley.edu/calnet-technologists/incommon-sectigo-certificate-service/addtrust-external-root-expiration-may-2020

Not sure if this is the right thing to do or to contact the developer and inform them about their certificate chain?
```
URLDownloader
{'Input': {'filename': u'SizeUp.zip',
           'request_headers': {
    "user-agent" = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17";
},
           'url': u'https://www.irradiatedsoftware.com/download/SizeUp.zip'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
curl failure: SSL certificate problem: certificate has expired
```