### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/LastPass/LastPass_Safari.pkg.recipe
+++ b/LastPass/LastPass_Safari.pkg.recipe
@@ -7,10 +7,7 @@
 	<key>Identifier</key>
 	<string>com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari</string>
 	<key>Input</key>
-	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.autopkg.pkg.lastpassforsafari</string>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>

--- a/ProcessMonitor/ProcessMonitor.pkg.recipe
+++ b/ProcessMonitor/ProcessMonitor.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.poundbangbash.eholtam-recipes.pkg.ProcessMonitor</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.sqwarq.Process-Monitor</string>
 		<key>NAME</key>
 		<string>Process Monitor</string>
 	</dict>

--- a/ThinkBuzan Limited/iMindMap 10.pkg.recipe
+++ b/ThinkBuzan Limited/iMindMap 10.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.ThinkBuzan.iMindMap 10.iMindMap 10</string>
 		<key>NAME</key>
 		<string>iMindMap 10</string>
 	</dict>

--- a/moonleo/PresentationFontEmbedder.pkg.recipe
+++ b/moonleo/PresentationFontEmbedder.pkg.recipe
@@ -9,10 +9,7 @@
 	<key>Identifier</key>
 	<string>com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder</string>
 	<key>Input</key>
-	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.presentationfontembedder.presentationfontembedder</string>
-	</dict>
+	<dict/>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ LastPass/LastPass_Safari.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/eholtam-recipes/LastPass/LastPass_Safari.pkg.recipe
Processing repos/eholtam-recipes/LastPass/LastPass_Safari.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://download.cloud.lastpass.com/mac/LastPass.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/downloads/LastPass.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/downloads/LastPass.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/downloads/LastPass.dmg/LastPass.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.lastpass.lastpassmacdesktop" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = N24REP3BMN)',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/downloads/LastPass.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.HJO6Ub/LastPass.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.HJO6Ub/LastPass.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.HJO6Ub/LastPass.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/downloads/LastPass.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ZDRZ4q/LastPass.app' matched from globbed '/private/tmp/dmg.ZDRZ4q/*.app'.
AppPkgCreator: Version: 4.64.0
AppPkgCreator: BundleID: com.lastpass.lastpassmacdesktop
AppPkgCreator: Copied /private/tmp/dmg.ZDRZ4q/LastPass.app to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/payload/Applications/LastPass.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.lastpass.lastpassmacdesktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/LastPass-4.64.0.pkg',
                                                        'version': '4.64.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.64.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/receipts/LastPass_Safari.pkg-receipt-20210213-225305.plist

The following packages were built:
    Identifier                       Version  Pkg Path                                                                                                               
    ----------                       -------  --------                                                                                                               
    com.lastpass.lastpassmacdesktop  4.64.0   ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.LastPass_Safari/LastPass-4.64.0.pkg  
```

## ❌ ProcessMonitor/ProcessMonitor.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/eholtam-recipes/ProcessMonitor/ProcessMonitor.pkg.recipe
Processing repos/eholtam-recipes/ProcessMonitor/ProcessMonitor.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://s3.amazonaws.com/sqwarq.com/AppCasts/procmon-updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.1
SparkleUpdateInfoProvider: Found URL https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip
{'Output': {'url': 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip',
            'version': '1.1'}}
URLDownloader
{'Input': {'filename': 'Process Monitor-1.1.zip',
           'url': 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.ProcessMonitor/receipts/ProcessMonitor.pkg-receipt-20210213-225307.plist

The following recipes failed:
    repos/eholtam-recipes/ProcessMonitor/ProcessMonitor.pkg.recipe
        Error in com.github.poundbangbash.eholtam-recipes.pkg.ProcessMonitor: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://s3.amazonaws.com/sqwarq.com/PublicZips/ProcessMonitor.app.zip', '--fail', '--output', '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.ProcessMonitor/downloads/tmpss5fnxwc']' returned non-zero exit status 22.

Nothing downloaded, packaged or imported.
```

## ✅ ThinkBuzan Limited/iMindMap 10.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/eholtam-recipes/ThinkBuzan\ Limited/iMindMap\ 10.pkg.recipe
Processing repos/eholtam-recipes/ThinkBuzan Limited/iMindMap 10.pkg.recipe...
URLDownloader
{'Input': {'filename': 'iMindMap 10.dmg',
           'url': 'https://imindmap.com/jump/imindmap10_mac_full/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap 10.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap '
                        '10.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap '
                         '10.dmg/iMindMap 10.app',
           'requirement': 'identifier "com.ThinkBuzan.iMindMap 10.iMindMap 10" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'LH9ZYYUWB4',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap 10.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.V89dd4/iMindMap 10.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.V89dd4/iMindMap 10.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.V89dd4/iMindMap 10.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap '
                               '10.dmg/iMindMap 10.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap 10.dmg
Versioner: Found version 10.0.174 in file /private/tmp/dmg.fjS7Ww/iMindMap 10.app/Contents/Info.plist
{'Output': {'version': '10.0.174'}}
AppPkgCreator
{'Input': {'version': '10.0.174'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/downloads/iMindMap 10.dmg
AppPkgCreator: Using path '/private/tmp/dmg.CCS7ok/iMindMap 10.app' matched from globbed '/private/tmp/dmg.CCS7ok/*.app'.
AppPkgCreator: BundleID: com.ThinkBuzan.iMindMap 10.iMindMap 10
AppPkgCreator: Copied /private/tmp/dmg.CCS7ok/iMindMap 10.app to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/payload/Applications/iMindMap 10.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.ThinkBuzan.iMindMap '
                                                                      '10.iMindMap '
                                                                      '10',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/iMindMap '
                                                                    '10-10.0.174.pkg',
                                                        'version': '10.0.174'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '10.0.174'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/receipts/iMindMap 10.pkg-receipt-20210213-225354.plist

The following packages were built:
    Identifier                              Version   Pkg Path                                                                                                               
    ----------                              -------   --------                                                                                                               
    com.ThinkBuzan.iMindMap 10.iMindMap 10  10.0.174  ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.iMindMap10/iMindMap 10-10.0.174.pkg  
```

## ✅ moonleo/PresentationFontEmbedder.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/eholtam-recipes/moonleo/PresentationFontEmbedder.pkg.recipe
Processing repos/eholtam-recipes/moonleo/PresentationFontEmbedder.pkg.recipe...
URLDownloader
{'Input': {'filename': 'PresentationFontEmbedder.dmg',
           'url': 'https://www.moonleo.com/downloads/Presentation%20Font%20Embedder.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/downloads/PresentationFontEmbedder.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/downloads/PresentationFontEmbedder.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/downloads/PresentationFontEmbedder.dmg/Presentation '
                         'Font Embedder.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.presentationfontembedder.presentationfontembedder" '
                          'and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = B2ZU2BY35K)',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/downloads/PresentationFontEmbedder.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.g8quQi/Presentation Font Embedder.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.g8quQi/Presentation Font Embedder.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.g8quQi/Presentation Font Embedder.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/downloads/PresentationFontEmbedder.dmg
AppPkgCreator: Using path '/private/tmp/dmg.8uTunl/Presentation Font Embedder.app' matched from globbed '/private/tmp/dmg.8uTunl/*.app'.
AppPkgCreator: Version: 2.24.0
AppPkgCreator: BundleID: com.presentationfontembedder.presentationfontembedder
AppPkgCreator: Copied /private/tmp/dmg.8uTunl/Presentation Font Embedder.app to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/payload/Applications/Presentation Font Embedder.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.presentationfontembedder.presentationfontembedder',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/Presentation '
                                                                    'Font '
                                                                    'Embedder-2.24.0.pkg',
                                                        'version': '2.24.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.24.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/receipts/PresentationFontEmbedder.pkg-receipt-20210213-225403.plist

The following packages were built:
    Identifier                                             Version  Pkg Path                                                                                                                                          
    ----------                                             -------  --------                                                                                                                                          
    com.presentationfontembedder.presentationfontembedder  2.24.0   ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.pkg.PresentationFontEmbedder/Presentation Font Embedder-2.24.0.pkg  
```

