### PR TITLE
iMazingHEICConverter

### DIFF
--- a/iMazingHEICConverter/ImazingHEICConverter.download.recipe
+++ b/iMazingHEICConverter/ImazingHEICConverter.download.recipe
@@ -16,15 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
- 			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://imazing.com/heic/download/macos</string>
-				<key>re_pattern</key>
-				<string>(https:\/\/[\S]+\.dmg)</string>
-			</dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://imazing.com/heic/download/macos</string>
+                <key>re_pattern</key>
+                <string>(https:\/\/[\S]+\.dmg)</string>
+            </dict>
         </dict>
         <dict>
             <key>Processor</key>
@@ -39,19 +39,19 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>strict_verification</key>
-				<true />
-				<key>input_path</key>
-				<string>%pathname%/iMazing HEIC Converter.app</string>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>strict_verification</key>
+                <true />
+                <key>input_path</key>
+                <string>%pathname%/iMazing Converter.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.DigiDNA.iMazingHEICConverterMac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = J5PR93692Y)</string>
-			</dict>
-		</dict>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/iMazingHEICConverter/ImazingHEICConverter.munki.recipe
+++ b/iMazingHEICConverter/ImazingHEICConverter.munki.recipe
@@ -26,8 +26,6 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-            <key>minimum_os_version</key>
-            <string>10.8.0</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Hi, @poundbangbash 

This PR contains the following changes:

Download Recipe

- Update the App's name to `iMazing Converter` in the `CodeSignatureVerifier` processor
- Linting (de-tabbing)

Munki Recipe

- Removes the `minimum_os_version` as `MunkiImporter` automatically grabs this from the Apps Info.plist

Thanks! 
Paul 

-vv output

```
autopkg run -vv /Users/paul/Documents/GitHub/eholtam-recipes/iMazingHEICConverter/ImazingHEICConverter.munki.recipe 
Processing /Users/paul/Documents/GitHub/eholtam-recipes/iMazingHEICConverter/ImazingHEICConverter.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/eholtam-recipes/iMazingHEICConverter/ImazingHEICConverter.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https:\\/\\/[\\S]+\\.dmg)',
           'url': 'https://imazing.com/heic/download/macos'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://downloads.imazing.com/mac/iMazing-Converter/iMazingConverterMac.dmg
{'Output': {'match': 'https://downloads.imazing.com/mac/iMazing-Converter/iMazingConverterMac.dmg'}}
URLDownloader
{'Input': {'url': 'https://downloads.imazing.com/mac/iMazing-Converter/iMazingConverterMac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 04 Jul 2022 17:37:14 GMT
URLDownloader: Storing new ETag header: "d33bee3b51b613a74c198ebf2fe77101"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg
{'Output': {'download_changed': True,
            'etag': '"d33bee3b51b613a74c198ebf2fe77101"',
            'last_modified': 'Mon, 04 Jul 2022 17:37:14 GMT',
            'pathname': '/Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg/iMazing '
                         'Converter.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.DigiDNA.iMazingHEICConverterMac" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'J5PR93692Y)',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.h7qxAt/iMazing Converter.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.h7qxAt/iMazing Converter.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.h7qxAt/iMazing Converter.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg',
           'pkginfo': {'catalogs': ['development-imazing-imazingheicconverter'],
                       'description': 'With iMazing HEIC Converter, you can '
                                      "adopt Apple's brand new format without "
                                      'worrying about compatibility with your '
                                      'older software. Simple, and truly free.',
                       'display_name': 'iMazing HEIC Converter',
                       'name': 'imazing-heic-converter',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/imazing'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/imazing/imazing-heic-converter-2.0.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/imazing/iMazingConverterMac-2.0.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'development-imazing-imazingheicconverter',
                                                       'icon_repo_path': '',
                                                       'name': 'imazing-heic-converter',
                                                       'pkg_repo_path': 'apps/imazing/iMazingConverterMac-2.0.0.dmg',
                                                       'pkginfo_path': 'apps/imazing/imazing-heic-converter-2.0.0.plist',
                                                       'version': '2.0.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'paul',
                                         'creation_date': datetime.datetime(2022, 7, 8, 10, 23, 16),
                                         'munki_version': '5.5.1.4365',
                                         'os_version': '12.4'},
                           'autoremove': False,
                           'catalogs': ['development-imazing-imazingheicconverter'],
                           'description': 'With iMazing HEIC Converter, you '
                                          "can adopt Apple's brand new format "
                                          'without worrying about '
                                          'compatibility with your older '
                                          'software. Simple, and truly free.',
                           'display_name': 'iMazing HEIC Converter',
                           'installer_item_hash': '7a2473be1df80f037e53e4ec570adfcbe608e2a3b9c3bbabfd96a0f3d04ec994',
                           'installer_item_location': 'apps/imazing/iMazingConverterMac-2.0.0.dmg',
                           'installer_item_size': 17026,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.DigiDNA.iMazingHEICConverterMac',
                                         'CFBundleName': 'iMazing Converter',
                                         'CFBundleShortVersionString': '2.0.0',
                                         'CFBundleVersion': '417',
                                         'minosversion': '10.10',
                                         'path': '/Applications/iMazing '
                                                 'Converter.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'iMazing '
                                                             'Converter.app'}],
                           'minimum_os_version': '10.10',
                           'name': 'imazing-heic-converter',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '2.0.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/imazing/iMazingConverterMac-2.0.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/imazing/imazing-heic-converter-2.0.0.plist'}}
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/receipts/ImazingHEICConverter.munki-receipt-20220708-112316.plist

The following new items were downloaded:
    Download Path                                                                                                                              
    -------------                                                                                                                              
    /Users/paul/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.munki.imazing-heic-converter/downloads/iMazingConverterMac.dmg  

The following new items were imported into Munki:
    Name                    Version  Catalogs                                  Pkginfo Path                                     Pkg Repo Path                               Icon Repo Path  
    ----                    -------  --------                                  ------------                                     -------------                               --------------  
    imazing-heic-converter  2.0.0    development-imazing-imazingheicconverter  apps/imazing/imazing-heic-converter-2.0.0.plist  apps/imazing/iMazingConverterMac-2.0.0.dmg
```

