### PR TITLE
Update download URL and code signature for Elgato TB2Dock download

### DIFF
--- a/elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe
+++ b/elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe
@@ -9,7 +9,7 @@
         <key>NAME</key>
         <string>elgatoThunderbolt2Dock</string>
         <key>DOWNLOAD_URL</key>
-        <string>https://dl.elgato.com/thunderbolt/dockutility/Elgato_Thunderbolt_Dock_Software_11_110.pkg</string>
+        <string>https://edge.elgato.com/thunderbolt-dock/Elgato_Thunderbolt_Dock_Software_1.2.10.131_40.pkg</string>
         <key>USER_AGENT</key>
         <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17</string>
     </dict>
@@ -42,7 +42,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Elgato Systems GmbH</string>
+					<string>Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
This PR updates the download URL for the Elgato Thunderbolt 2 Dock installer package.

I didn't go spelunking too far down this rabbit hole, but I did observe a parseable pkg URL contained in this JSON:

```
https://www.elgato.com/_next/data/no_-L7lN_MZh9WTtcjyaw/us/en/s/downloads.json
```

I would want to make sure I understood where the `no_-L7lN_MZh9WTtcjyaw` substring came from and whether it changes before I build recipes around it, but that could be an avenue of exploration if you're interested.

Verbose recipe run output:

```
% autopkg run -vvq 'elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe'
Processing elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe...
WARNING: elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'elgatoThunderbolt2Dock.pkg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_10_0) '
                                             'AppleWebKit/600.5.17 (KHTML, '
                                             'like Gecko) Version/8.0.5 '
                                             'Safari/600.5.17'},
           'url': 'https://edge.elgato.com/thunderbolt-dock/Elgato_Thunderbolt_Dock_Software_1.2.10.131_40.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 08 Oct 2019 18:23:50 GMT
URLDownloader: Storing new ETag header: "3c042d4baaefb00f44ad10baa868c512"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/downloads/elgatoThunderbolt2Dock.pkg
{'Output': {'download_changed': True,
            'etag': '"3c042d4baaefb00f44ad10baa868c512"',
            'last_modified': 'Tue, 08 Oct 2019 18:23:50 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/downloads/elgatoThunderbolt2Dock.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/downloads/elgatoThunderbolt2Dock.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Corsair '
                                        'Memory, Inc. (Y93VXCB8Q5)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/downloads/elgatoThunderbolt2Dock.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "elgatoThunderbolt2Dock.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2019-09-10 18:58:28 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Corsair Memory, Inc. (Y93VXCB8Q5)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            D0 FC 31 98 02 EA 2E 96 18 DB C7 DC F2 1D F7 2A AB 25 D4 AE 84 69
CodeSignatureVerifier:            2E 79 51 48 44 92 06 60 05 81
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/receipts/elgatoThunderbolt2Dock.download-receipt-20241227-205104.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.elgato.download.thunderbolt2Dock/downloads/elgatoThunderbolt2Dock.pkg
```
