### PR TITLE
Deprecate Snapz Pro recipes

### DIFF
--- a/SnapzPro/SnapzPro.download.recipe
+++ b/SnapzPro/SnapzPro.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Ambrosia Software is defunct and SnapzPro is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional SnapzPro recipes, since Ambrosia's website is fully offline now.
