### PR TITLE
Deprecate ProcessMonitor recipes

### DIFF
--- a/ProcessMonitor/ProcessMonitor.download.recipe
+++ b/ProcessMonitor/ProcessMonitor.download.recipe
@@ -16,9 +16,18 @@
 		<string>https://s3.amazonaws.com/sqwarq.com/AppCasts/procmon-updates.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the ProcessMonitor recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the non-functional ProcessMonitor recipes in this repo and points users to working equivalents in the zentral-recipes repo.
