### PR TITLE
Deprecate iMindMap 10 recipes

### DIFF
--- a/ThinkBuzan Limited/iMindMap 10.download.recipe
+++ b/ThinkBuzan Limited/iMindMap 10.download.recipe
@@ -19,6 +19,15 @@
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>iMindMap 10 is no longer available for download. iMindMap 11 is available (https://buzan.us/imindmap-download/) but there are no recipes for it yet. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the iMindMap 10 recipes, since that app is no longer available for download.

[iMindMap 11](https://buzan.us/imindmap-download/) is available, and it looks like it wouldn't be hard to create recipes for it — I'll leave that for you to decide.
