### PR TITLE
Update download URL pattern for Avid Codecs LE

### DIFF
--- a/AvidCodecsLE/AvidCodecsLE.download.recipe
+++ b/AvidCodecsLE/AvidCodecsLE.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://avid.force.com/pkb/articles/en_US/Download/Avid-QuickTime-Codecs-LE</string>
+				<string>https://avidtech.my.salesforce-sites.com/pkb/articles/en_US/Download/Avid-QuickTime-Codecs-LE</string>
 				<key>re_pattern</key>
 				<string>(http\:\/\/cdn.avid.com\/Codecs\/LE\/[0-9.]*\/\w+\/CodecsLE_[0-9.]*_Mac.pkg.zip)</string>
                 <key>request_headers</key>


### PR DESCRIPTION
This PR restores the Avid Codecs LE recipes to working order by updating the download URL pattern matching.

Verbose recipe run output:

```
% autopkg run -vvq 'AvidCodecsLE/AvidCodecsLE.download.recipe'
Processing AvidCodecsLE/AvidCodecsLE.download.recipe...
WARNING: AvidCodecsLE/AvidCodecsLE.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(http\\:\\/\\/cdn.avid.com\\/Codecs\\/LE\\/[0-9.]*\\/\\w+\\/CodecsLE_[0-9.]*_Mac.pkg.zip)',
           'request_headers': {'user-agent': 'Mozilla/5.0'},
           'url': 'https://avidtech.my.salesforce-sites.com/pkb/articles/en_US/Download/Avid-QuickTime-Codecs-LE'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): http://cdn.avid.com/Codecs/LE/2.7.3/0B9447EC/CodecsLE_2.7.3_Mac.pkg.zip
{'Output': {'match': 'http://cdn.avid.com/Codecs/LE/2.7.3/0B9447EC/CodecsLE_2.7.3_Mac.pkg.zip'}}
URLDownloader
{'Input': {'filename': 'AvidCodecsLE.zip',
           'request_headers': {'user-agent': 'Mozilla/5.0'},
           'url': 'http://cdn.avid.com/Codecs/LE/2.7.3/0B9447EC/CodecsLE_2.7.3_Mac.pkg.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 09 May 2024 18:05:42 GMT
URLDownloader: Storing new ETag header: "3298640f9b6e82c784f7f086174145c9"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip
{'Output': {'download_changed': True,
            'etag': '"3298640f9b6e82c784f7f086174145c9"',
            'last_modified': 'Thu, 09 May 2024 18:05:42 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/AvidCodecsLE',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename AvidCodecsLE.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/AvidCodecsLE
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Avid '
                                        'Technology Inc',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/AvidCodecsLE/AvidCodecsLE.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "AvidCodecsLE.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2019-12-05 13:38:17 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Avid Technology Inc (4UYUA773XD)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            34 FB DE 65 47 16 B2 BC A9 51 0D 59 CA 1F A0 46 A8 9A 7E 39 E7 0C
CodeSignatureVerifier:            7B DA 82 B2 B1 4A E7 E3 CC 01
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Mismatch in authority names
CodeSignatureVerifier: Expected: Developer ID Installer: Avid Technology Inc -> Developer ID Certification Authority -> Apple Root CA
CodeSignatureVerifier: Found:    Developer ID Installer: Avid Technology Inc (4UYUA773XD) -> Developer ID Certification Authority -> Apple Root CA
Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/receipts/AvidCodecsLE.download-receipt-20241227-201212.plist

The following recipes failed:
    AvidCodecsLE/AvidCodecsLE.download.recipe
        Error in com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE: Processor: CodeSignatureVerifier: Error: Mismatch in authority names. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.poundbangbash.eholtam-recipes.download.AvidCodecsLE/downloads/AvidCodecsLE.zip
```

