### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Amazon/KindleKidsBookCreator.download.recipe
+++ b/Amazon/KindleKidsBookCreator.download.recipe
@@ -28,6 +28,10 @@
                 <string>%NAME%.dmg</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -43,10 +47,6 @@
 				</array>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/AvidCodecsLE/AvidCodecsLE.download.recipe
+++ b/AvidCodecsLE/AvidCodecsLE.download.recipe
@@ -44,6 +44,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>Unarchiver</string>
 			<key>Arguments</key>
 			<dict>
@@ -69,10 +73,6 @@
 					<string>Apple Root CA</string>
 				</array>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Google Photos Backup/GooglePhotosBackup.download.recipe
+++ b/Google Photos Backup/GooglePhotosBackup.download.recipe
@@ -28,6 +28,10 @@
                 <string>%NAME%.dmg</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -41,10 +45,6 @@
                 <string>identifier "com.google.gpautobackup" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EQHXZ8M8AV</string>
     			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/MovaviScreenCaptureStudio/MovaviScreenCaptureStudio.download.recipe
+++ b/MovaviScreenCaptureStudio/MovaviScreenCaptureStudio.download.recipe
@@ -28,6 +28,10 @@
                 <string>%NAME%.dmg</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -43,10 +47,6 @@
 				</array>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/SizeUp/SizeUp.download.recipe
+++ b/SizeUp/SizeUp.download.recipe
@@ -33,6 +33,10 @@
                 </dict>
             </dict>
         </dict>
+       <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
  		<dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
@@ -59,10 +63,6 @@
 				<string>identifier "com.irradiatedsoftware.SizeUp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = GVZ7RF955D</string>
 			</dict>
 		</dict>
-       <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/SnapzPro/SnapzPro.download.recipe
+++ b/SnapzPro/SnapzPro.download.recipe
@@ -40,6 +40,10 @@
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
@@ -54,10 +58,6 @@
 				</array>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/SuspiciousPackageApp/SuspiciousPackageApp.download.recipe
+++ b/SuspiciousPackageApp/SuspiciousPackageApp.download.recipe
@@ -28,6 +28,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
@@ -38,10 +42,6 @@
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mothersruin.SuspiciousPackageApp" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "936EB786NH")</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Wondershare/UniConverter.download.recipe
+++ b/Wondershare/UniConverter.download.recipe
@@ -37,6 +37,10 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
 			<dict>
@@ -47,10 +51,6 @@
 				<key>requirement</key>
 				<string>identifier "com.Wondershare.Video-Converter-Ultimate" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YZC2T44ZDX</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe
+++ b/elgato-thunderbolt2dock/elgatoThunderbolt2Dock.download.recipe
@@ -34,6 +34,10 @@
             </dict>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 			<key>Arguments</key>
@@ -48,10 +52,6 @@
 				</array>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.